### PR TITLE
Fix array initialization

### DIFF
--- a/R/linesplit.R
+++ b/R/linesplit.R
@@ -13,13 +13,15 @@ linesplit <- function(str, return_as_arrow=FALSE) {
     stopifnot("str must be character" = is.character(str),
               "return_as_arrow must be logical" = is.logical(return_as_arrow))
 
-    arr <- nanoarrow_array_init(na_string())
-    stopifnot("arr is valid pointer" = nanoarrow_pointer_is_valid(arr),
+    arr <- nanoarrow_allocate_array()
+    stopifnot("arr does not already hold a value" = !nanoarrow_pointer_is_valid(arr),
               "arr is nanoarrow_array" = inherits(arr, "nanoarrow_array"))
 
     ##linesplit_impl(str, arr)
     linesplit_from_R_plain(str, arr)
     stopifnot("arr valid after linesplit" = nanoarrow_pointer_is_valid(arr))
+
+    nanoarrow_array_set_schema(arr, na_string())
 
     if (return_as_arrow) {
         stopifnot("return_as_arrow requires 'arrrow'" = requireNamespace("arrow", quietly=TRUE))


### PR DESCRIPTION
Fixes #2.

The leak here is because `nanoarrow_array_init()` allocates a special `ArrowArray` that nanoarrow knows how to modify (i.e., the release callback is non `NULL`). The linesplitter function here overwrites that release callback and so it's never called.

The intended pattern is `nanoarrow_array_allocate()`, which allocates the `ArrowArray` structure but does not populate it. To get it to work out-of-the box with other things, you also have to pin a schema to the array using `nanoarrow_array_set_schema()`.

I hope that helps!